### PR TITLE
enable plotting the timestep of maximum elevation

### DIFF
--- a/adcircpy/cmd/plot_maxele.py
+++ b/adcircpy/cmd/plot_maxele.py
@@ -7,23 +7,22 @@ from adcircpy.outputs import Maxele, TimeOfMaxEle
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Program to generate a plot of an ADCIRC `maxele` file."
+        description='Program to generate a plot of an ADCIRC `maxele` file.'
     )
-    parser.add_argument("maxele", help="Path to maxele file.")
+    parser.add_argument('maxele', help='Path to maxele file.')
     parser.add_argument(
-        "--plot_timestep_of_maxele",
-        help="Plot the timestep of the maximum elevation value",
-        action="store_true",
+        '--plot_timestep_of_maxele',
+        help='Plot the timestep of the maximum elevation value',
+        action='store_true',
     )
     parser.add_argument(
-        "--fort14",
-        help="Path to fort.14 file (required if maxele files is not netcdf).",
+        '--fort14', help='Path to fort.14 file (required if maxele files is not netcdf).',
     )
-    parser.add_argument("--title", help="Plot title override.")
-    parser.add_argument("--vmin", type=float)
-    parser.add_argument("--vmax", type=float)
-    parser.add_argument("--cmap", type=str, default="jet")
-    parser.add_argument("--levels", type=int, default=256)
+    parser.add_argument('--title', help='Plot title override.')
+    parser.add_argument('--vmin', type=float)
+    parser.add_argument('--vmax', type=float)
+    parser.add_argument('--cmap', type=str, default='jet')
+    parser.add_argument('--levels', type=int, default=256)
     return parser.parse_args()
 
 

--- a/adcircpy/cmd/plot_maxele.py
+++ b/adcircpy/cmd/plot_maxele.py
@@ -2,28 +2,37 @@ import argparse
 
 import matplotlib.pyplot as plt
 
-from adcircpy.outputs import Maxele
+from adcircpy.outputs import Maxele, TimeOfMaxEle
 
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description='Program to see a quick plot of an ADCIRC maxele file.'
+        description="Program to generate a plot of an ADCIRC `maxele` file."
     )
-    parser.add_argument('maxele', help='Path to maxele file.')
+    parser.add_argument("maxele", help="Path to maxele file.")
     parser.add_argument(
-        '--fort14', help='Path to fort.14 file (required if maxele files is not netcdf).',
+        "--plot_timestep_of_maxele",
+        help="Plot the timestep of the maximum elevation value",
+        action="store_true",
     )
-    parser.add_argument('--title', help='Plot title override.')
-    parser.add_argument('--vmin', type=float)
-    parser.add_argument('--vmax', type=float)
-    parser.add_argument('--cmap', type=str, default='jet')
-    parser.add_argument('--levels', type=int, default=256)
+    parser.add_argument(
+        "--fort14",
+        help="Path to fort.14 file (required if maxele files is not netcdf).",
+    )
+    parser.add_argument("--title", help="Plot title override.")
+    parser.add_argument("--vmin", type=float)
+    parser.add_argument("--vmax", type=float)
+    parser.add_argument("--cmap", type=str, default="jet")
+    parser.add_argument("--levels", type=int, default=256)
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
-    maxele = Maxele(args.maxele)
+    if args.plot_timestep_of_maxele:
+        maxele = TimeOfMaxEle(args.maxele)
+    else:
+        maxele = Maxele(args.maxele)
     maxele.tricontourf(
         vmin=args.vmin, vmax=args.vmax, cmap=args.cmap, levels=args.levels, cbar=True
     )

--- a/adcircpy/cmd/plot_maxele.py
+++ b/adcircpy/cmd/plot_maxele.py
@@ -2,7 +2,7 @@ import argparse
 
 import matplotlib.pyplot as plt
 
-from adcircpy.outputs import Maxele, TimeOfMaxEle
+from adcircpy.outputs import Maxele, MaximumElevationTimes
 
 
 def parse_args():
@@ -29,7 +29,7 @@ def parse_args():
 def main():
     args = parse_args()
     if args.plot_timestep_of_maxele:
-        maxele = TimeOfMaxEle(args.maxele)
+        maxele = MaximumElevationTimes(args.maxele)
     else:
         maxele = Maxele(args.maxele)
     maxele.tricontourf(

--- a/adcircpy/outputs/__init__.py
+++ b/adcircpy/outputs/__init__.py
@@ -3,7 +3,7 @@
 #     import ElevationStationsTimeseries
 from adcircpy.outputs.fort61 import ElevationStations, Fort61
 from adcircpy.outputs.fort63 import Fort63
-from adcircpy.outputs.maxele import Maxele, TimeOfMaxEle
+from adcircpy.outputs.maxele import Maxele, MaximumElevationTimes
 
 # from AdcircPy.Outputs.HarmonicConstituentsElevationStations import \
 #                                         HarmonicConstituentsElevationStations
@@ -12,7 +12,7 @@ __all__ = [
     # '_OutputFactory',
     # 'ElevationStationsTimeseries',
     'Maxele',
-    'TimeOfMaxEle',
+    'MaximumElevationTimes',
     'ElevationStations',
     'Fort61',
     'Fort63',

--- a/adcircpy/outputs/__init__.py
+++ b/adcircpy/outputs/__init__.py
@@ -3,7 +3,7 @@
 #     import ElevationStationsTimeseries
 from adcircpy.outputs.fort61 import ElevationStations, Fort61
 from adcircpy.outputs.fort63 import Fort63
-from adcircpy.outputs.maxele import Maxele
+from adcircpy.outputs.maxele import Maxele, TimeOfMaxEle
 
 # from AdcircPy.Outputs.HarmonicConstituentsElevationStations import \
 #                                         HarmonicConstituentsElevationStations
@@ -11,9 +11,10 @@ from adcircpy.outputs.maxele import Maxele
 __all__ = [
     # '_OutputFactory',
     # 'ElevationStationsTimeseries',
-    'Maxele',
-    'ElevationStations',
-    'Fort61',
-    'Fort63',
+    "Maxele",
+    "TimeOfMaxEle",
+    "ElevationStations",
+    "Fort61",
+    "Fort63",
     # 'HarmonicConstituentsElevationStations'
 ]

--- a/adcircpy/outputs/__init__.py
+++ b/adcircpy/outputs/__init__.py
@@ -11,10 +11,10 @@ from adcircpy.outputs.maxele import Maxele, TimeOfMaxEle
 __all__ = [
     # '_OutputFactory',
     # 'ElevationStationsTimeseries',
-    "Maxele",
-    "TimeOfMaxEle",
-    "ElevationStations",
-    "Fort61",
-    "Fort63",
+    'Maxele',
+    'TimeOfMaxEle',
+    'ElevationStations',
+    'Fort61',
+    'Fort63',
     # 'HarmonicConstituentsElevationStations'
 ]

--- a/adcircpy/outputs/base.py
+++ b/adcircpy/outputs/base.py
@@ -22,9 +22,9 @@ class SurfaceOutput(metaclass=abc.ABCMeta):
     # change this for __types__
 
     _physical_variables = {
-        "fort.63": "zeta",
-        "maxele": "zeta_max",
-        "time_of_maxele": "time_of_zeta_max",
+        'fort.63': 'zeta',
+        'maxele': 'zeta_max',
+        'time_of_maxele': 'time_of_zeta_max',
     }
 
     def __init__(self, path, crs=None):
@@ -34,14 +34,12 @@ class SurfaceOutput(metaclass=abc.ABCMeta):
     def export(self, path, overwrite=False):
         coords = {i + 1: (self.x[i], self.y[i]) for i in range(len(self.values))}
         values = self.values.filled(99999.0)
-        nodes = {
-            id: ((x, y), values[i]) for i, (id, (x, y)) in enumerate(coords.items())
-        }
+        nodes = {id: ((x, y), values[i]) for i, (id, (x, y)) in enumerate(coords.items())}
         triangles = {id + 1: tuple(e) for id, e in enumerate(self.triangles + 1)}
-        sms2dm.writer({"ND": nodes, "E3T": triangles}, path, overwrite)
+        sms2dm.writer({'ND': nodes, 'E3T': triangles}, path, overwrite)
 
     @figure
-    def triplot(self, *args, axes=None, color="k", linewidth=0.1, **kwargs):
+    def triplot(self, *args, axes=None, color='k', linewidth=0.1, **kwargs):
         plt.triplot(self.x, self.y, self.triangles, color=color, linewidth=linewidth)
         return axes
 
@@ -54,40 +52,40 @@ class SurfaceOutput(metaclass=abc.ABCMeta):
         _ax = plt.tricontourf(
             self.triangulation,
             self.values,
-            cmap=kwargs.get("cmap", self._cmap),
-            levels=kwargs.get("levels", self._levels),
-            vmin=kwargs.get("vmin", np.min(self.values)),
-            vmax=kwargs.get("vmax", np.max(self.values)),
+            cmap=kwargs.get('cmap', self._cmap),
+            levels=kwargs.get('levels', self._levels),
+            vmin=kwargs.get('vmin', np.min(self.values)),
+            vmax=kwargs.get('vmax', np.max(self.values)),
         )
         self.triangulation.set_mask(None)
-        if kwargs.get("cbar") is not None:
+        if kwargs.get('cbar') is not None:
             plt.colorbar(_ax)
-        plt.gca().axis("scaled")
+        plt.gca().axis('scaled')
         return axes
 
     @property
     @lru_cache(maxsize=None)
     def x(self):
         if isinstance(self._ptr, Dataset):
-            return self._ptr["x"][:].data
+            return self._ptr['x'][:].data
         else:
-            raise NotImplementedError("ascii")
+            raise NotImplementedError('ascii')
 
     @property
     @lru_cache(maxsize=None)
     def y(self):
         if isinstance(self._ptr, Dataset):
-            return self._ptr["y"][:].data
+            return self._ptr['y'][:].data
         else:
-            raise NotImplementedError("ascii")
+            raise NotImplementedError('ascii')
 
     @property
     @lru_cache(maxsize=None)
     def triangles(self):
         if isinstance(self._ptr, Dataset):
-            return self._ptr["element"][:].data - 1
+            return self._ptr['element'][:].data - 1
         else:
-            raise NotImplementedError("ascii")
+            raise NotImplementedError('ascii')
 
     @property
     @lru_cache(maxsize=None)
@@ -111,7 +109,7 @@ class SurfaceOutput(metaclass=abc.ABCMeta):
         path = pathlib.Path(path)
 
         if not path.is_file():
-            raise IOError(f"File not found: {str(path)}")
+            raise IOError(f'File not found: {str(path)}')
         self.__path = path
 
     @property
@@ -158,27 +156,27 @@ class SurfaceOutput(metaclass=abc.ABCMeta):
     def _ptr(self):
         try:
             nc = Dataset(self._path)
-            msg = "NetCDF file provided is not a surface output."
-            assert "adcirc_mesh" in nc.variables, msg
+            msg = 'NetCDF file provided is not a surface output.'
+            assert 'adcirc_mesh' in nc.variables, msg
             msg = f'"{self._physical_variable}" variable not found in file: '
-            msg += f"{self._path}, "
-            msg += f"therefore, this is not a {self._filetype} file."
+            msg += f'{self._path}, '
+            msg += f'therefore, this is not a {self._filetype} file.'
             assert self._physical_variable in nc.variables, msg
             return nc
         except OSError as e:
             if e.errno == -51:
                 if self._is_ascii:
-                    raise NotImplementedError("ASCII outputs are not implemented.")
+                    raise NotImplementedError('ASCII outputs are not implemented.')
                     values = self._get_ascii_values(0)
-                    return {f"{self._physical_variable}": values}
+                    return {f'{self._physical_variable}': values}
             raise e
 
     @property
     def _is_ascii(self):
         try:
-            with open(self._path, "r") as f:
+            with open(self._path, 'r') as f:
                 f.readline()
-                if "FileFmtVersion" in f.readline():
+                if 'FileFmtVersion' in f.readline():
                     return True
             return False
         except:  # noqa: E722
@@ -209,7 +207,7 @@ class SurfaceOutputTimeseries(SurfaceOutput):
             raise StopIteration
 
     def __len__(self):
-        return self._ptr.dimensions["time"].size
+        return self._ptr.dimensions['time'].size
 
     @property
     def index(self):
@@ -220,7 +218,7 @@ class SurfaceOutputTimeseries(SurfaceOutput):
         if isinstance(self._ptr, Dataset):
             self._values = self._ptr[self._physical_variable][index, :]
         else:
-            raise NotImplementedError("ascii")
+            raise NotImplementedError('ascii')
         self.__index = index
 
     @property
@@ -232,7 +230,7 @@ class SurfaceOutputTimeseries(SurfaceOutput):
 class ScalarSurfaceOutputTimeseries(SurfaceOutputTimeseries):
     def animation(self, save=False, fps=3, start_frame=0, end_frame=-1, **kwargs):
 
-        fig = plt.figure(figsize=kwargs.get("figsize"))
+        fig = plt.figure(figsize=kwargs.get('figsize'))
         ax = fig.add_subplot(111)
         plt.tight_layout(pad=2)
         _oi = self.index
@@ -251,20 +249,20 @@ class ScalarSurfaceOutputTimeseries(SurfaceOutputTimeseries):
                     np.any(self.values.mask[self.triangulation.triangles], axis=1)
                 )
 
-            if kwargs.get("elements", False):
-                ax.triplot(self.triangulation, color="k", linewidth=0.7)
+            if kwargs.get('elements', False):
+                ax.triplot(self.triangulation, color='k', linewidth=0.7)
 
             _ax = ax.tricontourf(
                 self.triangulation,
                 self.values,
-                cmap=kwargs.get("cmap", self._cmap),
-                levels=kwargs.get("levels", self._levels),
+                cmap=kwargs.get('cmap', self._cmap),
+                levels=kwargs.get('levels', self._levels),
             )
-            ax.set_ylim(ymin=kwargs.get("ymin"), ymax=kwargs.get("ymax"), auto=True)
-            ax.set_xlim(xmin=kwargs.get("xmin"), xmax=kwargs.get("xmax"), auto=True)
+            ax.set_ylim(ymin=kwargs.get('ymin'), ymax=kwargs.get('ymax'), auto=True)
+            ax.set_xlim(xmin=kwargs.get('xmin'), xmax=kwargs.get('xmax'), auto=True)
             # ax.set_title(dates[i].strftime('%b %d, %Y %H:%M'))
-            ax.set_xlabel("Longitude (°E)")
-            ax.set_ylabel("Latitude (°N)")
+            ax.set_xlabel('Longitude (°E)')
+            ax.set_ylabel('Latitude (°N)')
             # cbar = fig.colorbar(_ax, cax=cax, format='%.1f')
             # cbar.ax.set_ylabel('UNITS', rotation=90)
 
@@ -274,11 +272,11 @@ class ScalarSurfaceOutputTimeseries(SurfaceOutputTimeseries):
         anim = FuncAnimation(fig, animate, frames, blit=False)
 
         if save:
-            anim.save(pathlib.Path(save), writer="imagemagick", fps=fps)
+            anim.save(pathlib.Path(save), writer='imagemagick', fps=fps)
 
         self.index = _oi
 
-        if kwargs.get("show", False):
+        if kwargs.get('show', False):
             plt.show()
 
         return anim

--- a/adcircpy/outputs/base.py
+++ b/adcircpy/outputs/base.py
@@ -12,6 +12,8 @@ from pyproj import CRS
 from adcircpy.figures import figure
 from adcircpy.mesh.parsers import sms2dm
 
+import traceback
+
 # class OutputVariable(Enum):
 #     FORT63 = 'zeta'
 
@@ -19,7 +21,11 @@ from adcircpy.mesh.parsers import sms2dm
 class SurfaceOutput(metaclass=abc.ABCMeta):
     # change this for __types__
 
-    _physical_variables = {'fort.63': 'zeta', 'maxele': 'zeta_max'}
+    _physical_variables = {
+        "fort.63": "zeta",
+        "maxele": "zeta_max",
+        "time_of_maxele": "time_of_zeta_max",
+    }
 
     def __init__(self, path, crs=None):
         self._path = path
@@ -28,12 +34,14 @@ class SurfaceOutput(metaclass=abc.ABCMeta):
     def export(self, path, overwrite=False):
         coords = {i + 1: (self.x[i], self.y[i]) for i in range(len(self.values))}
         values = self.values.filled(99999.0)
-        nodes = {id: ((x, y), values[i]) for i, (id, (x, y)) in enumerate(coords.items())}
+        nodes = {
+            id: ((x, y), values[i]) for i, (id, (x, y)) in enumerate(coords.items())
+        }
         triangles = {id + 1: tuple(e) for id, e in enumerate(self.triangles + 1)}
-        sms2dm.writer({'ND': nodes, 'E3T': triangles}, path, overwrite)
+        sms2dm.writer({"ND": nodes, "E3T": triangles}, path, overwrite)
 
     @figure
-    def triplot(self, *args, axes=None, color='k', linewidth=0.1, **kwargs):
+    def triplot(self, *args, axes=None, color="k", linewidth=0.1, **kwargs):
         plt.triplot(self.x, self.y, self.triangles, color=color, linewidth=linewidth)
         return axes
 
@@ -46,40 +54,40 @@ class SurfaceOutput(metaclass=abc.ABCMeta):
         _ax = plt.tricontourf(
             self.triangulation,
             self.values,
-            cmap=kwargs.get('cmap', self._cmap),
-            levels=kwargs.get('levels', self._levels),
-            vmin=kwargs.get('vmin', np.min(self.values)),
-            vmax=kwargs.get('vmax', np.max(self.values)),
+            cmap=kwargs.get("cmap", self._cmap),
+            levels=kwargs.get("levels", self._levels),
+            vmin=kwargs.get("vmin", np.min(self.values)),
+            vmax=kwargs.get("vmax", np.max(self.values)),
         )
         self.triangulation.set_mask(None)
-        if kwargs.get('cbar') is not None:
+        if kwargs.get("cbar") is not None:
             plt.colorbar(_ax)
-        plt.gca().axis('scaled')
+        plt.gca().axis("scaled")
         return axes
 
     @property
     @lru_cache(maxsize=None)
     def x(self):
         if isinstance(self._ptr, Dataset):
-            return self._ptr['x'][:].data
+            return self._ptr["x"][:].data
         else:
-            raise NotImplementedError('ascii')
+            raise NotImplementedError("ascii")
 
     @property
     @lru_cache(maxsize=None)
     def y(self):
         if isinstance(self._ptr, Dataset):
-            return self._ptr['y'][:].data
+            return self._ptr["y"][:].data
         else:
-            raise NotImplementedError('ascii')
+            raise NotImplementedError("ascii")
 
     @property
     @lru_cache(maxsize=None)
     def triangles(self):
         if isinstance(self._ptr, Dataset):
-            return self._ptr['element'][:].data - 1
+            return self._ptr["element"][:].data - 1
         else:
-            raise NotImplementedError('ascii')
+            raise NotImplementedError("ascii")
 
     @property
     @lru_cache(maxsize=None)
@@ -101,8 +109,9 @@ class SurfaceOutput(metaclass=abc.ABCMeta):
     @_path.setter
     def _path(self, path):
         path = pathlib.Path(path)
+
         if not path.is_file():
-            raise IOError(f'File not found: {str(path)}')
+            raise IOError(f"File not found: {str(path)}")
         self.__path = path
 
     @property
@@ -149,27 +158,27 @@ class SurfaceOutput(metaclass=abc.ABCMeta):
     def _ptr(self):
         try:
             nc = Dataset(self._path)
-            msg = 'NetCDF file provided is not a surface output.'
-            assert 'adcirc_mesh' in nc.variables, msg
+            msg = "NetCDF file provided is not a surface output."
+            assert "adcirc_mesh" in nc.variables, msg
             msg = f'"{self._physical_variable}" variable not found in file: '
-            msg += f'{self._path}, '
-            msg += f'therefore, this is not a {self._filetype} file.'
+            msg += f"{self._path}, "
+            msg += f"therefore, this is not a {self._filetype} file."
             assert self._physical_variable in nc.variables, msg
             return nc
         except OSError as e:
             if e.errno == -51:
                 if self._is_ascii:
-                    raise NotImplementedError('ASCII outputs are not implemented.')
+                    raise NotImplementedError("ASCII outputs are not implemented.")
                     values = self._get_ascii_values(0)
-                    return {f'{self._physical_variable}': values}
+                    return {f"{self._physical_variable}": values}
             raise e
 
     @property
     def _is_ascii(self):
         try:
-            with open(self._path, 'r') as f:
+            with open(self._path, "r") as f:
                 f.readline()
-                if 'FileFmtVersion' in f.readline():
+                if "FileFmtVersion" in f.readline():
                     return True
             return False
         except:  # noqa: E722
@@ -200,7 +209,7 @@ class SurfaceOutputTimeseries(SurfaceOutput):
             raise StopIteration
 
     def __len__(self):
-        return self._ptr.dimensions['time'].size
+        return self._ptr.dimensions["time"].size
 
     @property
     def index(self):
@@ -211,7 +220,7 @@ class SurfaceOutputTimeseries(SurfaceOutput):
         if isinstance(self._ptr, Dataset):
             self._values = self._ptr[self._physical_variable][index, :]
         else:
-            raise NotImplementedError('ascii')
+            raise NotImplementedError("ascii")
         self.__index = index
 
     @property
@@ -223,7 +232,7 @@ class SurfaceOutputTimeseries(SurfaceOutput):
 class ScalarSurfaceOutputTimeseries(SurfaceOutputTimeseries):
     def animation(self, save=False, fps=3, start_frame=0, end_frame=-1, **kwargs):
 
-        fig = plt.figure(figsize=kwargs.get('figsize'))
+        fig = plt.figure(figsize=kwargs.get("figsize"))
         ax = fig.add_subplot(111)
         plt.tight_layout(pad=2)
         _oi = self.index
@@ -242,20 +251,20 @@ class ScalarSurfaceOutputTimeseries(SurfaceOutputTimeseries):
                     np.any(self.values.mask[self.triangulation.triangles], axis=1)
                 )
 
-            if kwargs.get('elements', False):
-                ax.triplot(self.triangulation, color='k', linewidth=0.7)
+            if kwargs.get("elements", False):
+                ax.triplot(self.triangulation, color="k", linewidth=0.7)
 
             _ax = ax.tricontourf(
                 self.triangulation,
                 self.values,
-                cmap=kwargs.get('cmap', self._cmap),
-                levels=kwargs.get('levels', self._levels),
+                cmap=kwargs.get("cmap", self._cmap),
+                levels=kwargs.get("levels", self._levels),
             )
-            ax.set_ylim(ymin=kwargs.get('ymin'), ymax=kwargs.get('ymax'), auto=True)
-            ax.set_xlim(xmin=kwargs.get('xmin'), xmax=kwargs.get('xmax'), auto=True)
+            ax.set_ylim(ymin=kwargs.get("ymin"), ymax=kwargs.get("ymax"), auto=True)
+            ax.set_xlim(xmin=kwargs.get("xmin"), xmax=kwargs.get("xmax"), auto=True)
             # ax.set_title(dates[i].strftime('%b %d, %Y %H:%M'))
-            ax.set_xlabel('Longitude (°E)')
-            ax.set_ylabel('Latitude (°N)')
+            ax.set_xlabel("Longitude (°E)")
+            ax.set_ylabel("Latitude (°N)")
             # cbar = fig.colorbar(_ax, cax=cax, format='%.1f')
             # cbar.ax.set_ylabel('UNITS', rotation=90)
 
@@ -265,11 +274,11 @@ class ScalarSurfaceOutputTimeseries(SurfaceOutputTimeseries):
         anim = FuncAnimation(fig, animate, frames, blit=False)
 
         if save:
-            anim.save(pathlib.Path(save), writer='imagemagick', fps=fps)
+            anim.save(pathlib.Path(save), writer="imagemagick", fps=fps)
 
         self.index = _oi
 
-        if kwargs.get('show', False):
+        if kwargs.get("show", False):
             plt.show()
 
         return anim

--- a/adcircpy/outputs/maxele.py
+++ b/adcircpy/outputs/maxele.py
@@ -2,11 +2,11 @@ from adcircpy.outputs.base import SurfaceOutput
 
 
 class Maxele(SurfaceOutput):
-    _filetype = "maxele"
+    _filetype = 'maxele'
 
 
 class TimeOfMaxEle(SurfaceOutput):
-    _filetype = "time_of_maxele"
+    _filetype = 'time_of_maxele'
 
 
 # import numpy as np

--- a/adcircpy/outputs/maxele.py
+++ b/adcircpy/outputs/maxele.py
@@ -2,7 +2,11 @@ from adcircpy.outputs.base import SurfaceOutput
 
 
 class Maxele(SurfaceOutput):
-    _filetype = 'maxele'
+    _filetype = "maxele"
+
+
+class TimeOfMaxEle(SurfaceOutput):
+    _filetype = "time_of_maxele"
 
 
 # import numpy as np

--- a/adcircpy/outputs/maxele.py
+++ b/adcircpy/outputs/maxele.py
@@ -5,7 +5,7 @@ class Maxele(SurfaceOutput):
     _filetype = 'maxele'
 
 
-class TimeOfMaxEle(SurfaceOutput):
+class MaximumElevationTimes(SurfaceOutput):
     _filetype = 'time_of_maxele'
 
 


### PR DESCRIPTION
* This modification enables plotting of the timestep the maximum value occurred. 

* For diagnosing model runs (particularly non-fatal instabilities) it's often very useful to look at when in the simulation a maximum elevation value occurred. The idea being, if the maximum elevation value occured at a timestep different from it's neighbors in the larger study region, it's perhaps a non-fatal instability or a blocked channel etc. 
```
plot_maxele maxele.63.nc --plot_timestep_of_maxele
```

PS: 

I still don't understand what's going on in `maxele.py`. I just created another class but seems like there's some implicit things happening here when the `_filetype` is assigned. Perhaps it'd better to make those actions more explicit?
![timestep_of_maximum_elevation](https://user-images.githubusercontent.com/18619644/120109144-9234d080-c13e-11eb-983d-7b6635c8f228.png)

