### PR TITLE
Correcting WTIMINC line for vortex forcing (NWS = 8, 19, 20).

### DIFF
--- a/adcircpy/forcing/winds/best_track.py
+++ b/adcircpy/forcing/winds/best_track.py
@@ -910,15 +910,6 @@ class BestTrackForcing(VortexForcing, WindForcing):
         self.__NWS = int(NWS)
 
     @property
-    def WTIMINC(self) -> str:
-        return (
-            f'{self.start_date:%Y %m %d %H} '
-            f'{self.data["storm_number"].iloc[0]} '
-            f'{self.BLADj} '
-            f'{self.geofactor}'
-        )
-
-    @property
     def BLADj(self) -> float:
         try:
             return self.__BLADj

--- a/adcircpy/fort15.py
+++ b/adcircpy/fort15.py
@@ -1430,10 +1430,10 @@ class Fort15:
                 f'{self.wind_forcing.BLADj} '
                 f'{self.wind_forcing.geofactor}'
             )
-        elif self.NWS not in [0, 1, 9, 11]:
-            return int(self.wind_forcing.interval / timedelta(seconds=1))
-        else:
+        elif self.NWS in [0, 1, 9, 11]:
             return 0
+        else:
+            return int(self.wind_forcing.interval / timedelta(seconds=1))
 
     @property
     def RSTIMINC(self) -> int:

--- a/adcircpy/fort15.py
+++ b/adcircpy/fort15.py
@@ -1422,9 +1422,14 @@ class Fort15:
         self.__REFTIM = float(REFTIM)
 
     @property
-    def WTIMINC(self) -> int:
+    def WTIMINC(self):
         if self.NWS in [8, 19, 20]:
-            return self.wind_forcing.WTIMINC
+            return (
+                f'{self.forcing_start_date:%Y %m %d %H} '
+                f'{self.wind_forcing.data["storm_number"].iloc[0]} '
+                f'{self.wind_forcing.BLADj} '
+                f'{self.wind_forcing.geofactor}'
+            )
         elif self.NWS not in [0, 1, 9, 11]:
             return int(self.wind_forcing.interval / timedelta(seconds=1))
         else:

--- a/adcircpy/fort15.py
+++ b/adcircpy/fort15.py
@@ -3,7 +3,7 @@ from enum import Enum
 import math
 from os import PathLike
 import pathlib
-from typing import Any
+from typing import Any, Union
 
 import numpy as np
 
@@ -1422,7 +1422,7 @@ class Fort15:
         self.__REFTIM = float(REFTIM)
 
     @property
-    def WTIMINC(self):
+    def WTIMINC(self) -> Union[int, str]:
         if self.NWS in [8, 19, 20]:
             return (
                 f'{self.forcing_start_date:%Y %m %d %H} '

--- a/tests/data/reference/test_best_track_run/fort.15.coldstart
+++ b/tests/data/reference/test_best_track_run/fort.15.coldstart
@@ -1,4 +1,4 @@
-created on 2021-09-02 09:39                                     ! RUNDES                              - 32 CHARACTER ALPHANUMERIC RUN DESCRIPTION
+created on 2021-09-03 09:14                                     ! RUNDES                              - 32 CHARACTER ALPHANUMERIC RUN DESCRIPTION
 Shinacock Inlet Coarse Grid                                     ! RUNID                               - 24 CHARACTER ALPANUMERIC RUN IDENTIFICATION
 1                                                               ! NFOVER                              - NONFATAL ERROR OVERRIDE OPTION
 1                                                               ! NABOUT                              - ABREVIATED OUTPUT OPTION PARAMETER

--- a/tests/data/reference/test_best_track_run/fort.15.hotstart
+++ b/tests/data/reference/test_best_track_run/fort.15.hotstart
@@ -1,4 +1,4 @@
-created on 2021-09-02 09:40                                     ! RUNDES                              - 32 CHARACTER ALPHANUMERIC RUN DESCRIPTION
+created on 2021-09-03 09:15                                     ! RUNDES                              - 32 CHARACTER ALPHANUMERIC RUN DESCRIPTION
 Shinacock Inlet Coarse Grid                                     ! RUNID                               - 24 CHARACTER ALPANUMERIC RUN IDENTIFICATION
 1                                                               ! NFOVER                              - NONFATAL ERROR OVERRIDE OPTION
 1                                                               ! NABOUT                              - ABREVIATED OUTPUT OPTION PARAMETER
@@ -21,7 +21,7 @@ primitive_weighting_in_continuity_equation
 10.000000                                                       ! DTDP                                - TIME STEP (IN SECONDS)
 0                                                               ! STATIM                              - STARTING TIME (IN DAYS)
 0                                                               ! REFTIM                              - REFERENCE TIME (IN DAYS)
-2012 10 28 18 18 0.9 1                                          ! WTIMINC                             - meteorological data time increment
+2012 10 28 06 18 0.9 1                                          ! WTIMINC                             - meteorological data time increment
 1                                                               ! RNDAY                               - TOTAL LENGTH OF SIMULATION (IN DAYS)
 0.500 0.000 0.000 0.000 0.500 0.500 1.000 0.000 0.500           ! DRAMP                               - DURATION OF RAMP FUNCTION (IN DAYS)
 0.5 0.5 0                                                       ! A00 B00 C00                         - TIME WEIGHTING FACTORS FOR THE GWCE EQUATION


### PR DESCRIPTION
moving `WTIMINC` for `BestTrackForcing` class into `fort15.py` so can use the coldstart time instead of vortex start time on `WTIMINC` fort.15 line

addresses #123 

@zacharyburnettNOAA I executed `generate_adcirc` CLI from the test case you gave me and it now is populating the fort.15 WTIMINC line correctly. 